### PR TITLE
Mark safe as a secure protocol to enable latest HTML5 features

### DIFF
--- a/app/lib/fg/import-web-apis.js
+++ b/app/lib/fg/import-web-apis.js
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron'
+import { ipcRenderer, webFrame } from 'electron'
 import rpc from 'pauls-electron-rpc'
 
 // it would be better to import this from package.json
@@ -6,6 +6,9 @@ const BEAKER_VERSION = '0.0.1'
 
 // method which will populate window.beaker with the APIs deemed appropriate for the protocol
 export default function () {
+
+  // mark the safe protocol as 'secure' to enable all DOM APIs
+  webFrame.registerURLSchemeAsSecure('safe');
   window.beaker = { version: BEAKER_VERSION }
   var webAPIs = ipcRenderer.sendSync('get-web-api-manifests', window.location.protocol)
   for (var k in webAPIs) {


### PR DESCRIPTION
Chrom(e|ium) exposes many newer DOM APIs and HTML5 features (like User Media or Geolocation) only over secure connections – primarily https – in order to prevent the user from accidentally exposing themselves to third parties. For any webpage deliver over an unsecure protocol those APIs will be flat out denied.

This patch registers our own `safe`-protocol as a secure one, in order to enable said DOM APIs and HTML5 features.

Fixes #9 .
